### PR TITLE
Configure CORS allowed origins and add tests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -57,8 +57,24 @@ def create_app():
     # This is the connection between the Flask app, the SQLAlchemy database and the Migrate database. It allows the app to manage database migrations.
     migrate.init_app(app, db) # Now, both SQLAlchemy and Migrate are connected to Flask app.
 
-    # Enable CORS for all routes and origins. It allows your frontend to communicate with your backend.
-    CORS(app)
+    # Enable CORS using the allowed origins defined in the configuration. This prevents unexpected
+    # cross-origin requests from being accepted while still allowing the trusted frontends to
+    # communicate with the backend.
+    allowed_origins = [
+        origin.strip()
+        for origin in app.config.get('CORS_ORIGINS', [])
+        if origin and origin.strip()
+    ]
+    CORS(
+        app,
+        resources={
+            r"/*": {
+                "origins": allowed_origins,
+                "methods": ["GET", "POST", "OPTIONS"],
+                "allow_headers": ["Content-Type", "Authorization"],
+            }
+        },
+    )
 
     # Initialize Flask-Login
     login_manager.init_app(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+import pytest
+
+DEFAULT_ALLOWED_ORIGIN = "http://allowed.test"
+os.environ.setdefault("CORS_ORIGINS", DEFAULT_ALLOWED_ORIGIN)
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from app import create_app  # noqa: E402  pylint: disable=wrong-import-position
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update({
+        "TESTING": True,
+    })
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def allowed_origin():
+    return DEFAULT_ALLOWED_ORIGIN

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,10 @@
+def test_allowed_origin_receives_cors_headers(client, allowed_origin):
+    response = client.get("/index", headers={"Origin": allowed_origin})
+    assert response.headers.get("Access-Control-Allow-Origin") == allowed_origin
+
+
+def test_disallowed_origin_does_not_receive_cors_headers(client):
+    response = client.get(
+        "/index", headers={"Origin": "http://malicious.test"}
+    )
+    assert "Access-Control-Allow-Origin" not in response.headers


### PR DESCRIPTION
## Summary
- configure Flask CORS to respect the configured list of allowed origins and limit exposed methods/headers
- add pytest fixtures to bootstrap the application under test with a deterministic CORS origin
- create regression tests covering both allowed and disallowed origins

## Testing
- `pip install -r dependencies/requirements.txt` *(fails: proxy blocks access to PyPI, preventing installation)*
- `pytest` *(fails: missing Flask dependency because packages could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d128fa9fbc832d9abbfec54962aa29